### PR TITLE
Browser override handling

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,8 +1,11 @@
 'use strict';
 const sysPath = require('path');
+const fs = require('fs');
 
 const isRelative = path => path.slice(0, 2) === './' || path.slice(0, 3) === '../';
 const makeRelative = path => path.replace(process.cwd() + sysPath.sep, '');
 const not = f => i => !f(i);
 
-module.exports = {makeRelative, isRelative, not};
+const exists = path => new Promise(resolve => fs.exists(path, resolve));
+
+module.exports = {makeRelative, isRelative, not, exists};

--- a/lib/modules.js
+++ b/lib/modules.js
@@ -2,6 +2,7 @@
 
 const sysPath = require('path');
 const stat = require('micro-promisify')(require('fs').stat);
+const logger = require('loggy');
 const helpers = require('./helpers');
 const shims = require('./shims');
 const moduleDefinitions = require('./module-definitions');
@@ -28,8 +29,10 @@ const relativeToRoot = (filePath, relPath) => sysPath.join(
 
 const getMainCached = (rootMainCache, path) => rootMainCache[getModuleRootPath(path)];
 const cacheMain = (getPackageJson, rootMainCache, path) => {
+  const rootPath = getModuleRootPath(path);
+  if (rootMainCache[rootPath]) return Promise.resolve();
   return _getMainFile(getPackageJson, path)
-    .then(file => rootMainCache[getModuleRootPath(path)] = file);
+    .then(file => rootMainCache[rootPath] = file);
 };
 
 const relativeOverrides = (path, brMap) => {
@@ -113,6 +116,13 @@ const _getMainFile = (getPackageJson, filePath) => {
       const pkg = getPackageJson(main);
       const brMap = _browserMappings(pkg, main, main);
       return mappedMainFile(brMap, main);
+    }).then(main => {
+      return helpers.exists(main).then(exists => {
+        if (exists || sysPath.relative(root, main) === 'index.js') return main;
+
+        logger.warn(`main file for module ${json.name} does not exist (${sysPath.relative(process.cwd(), main)}), assuming index.js`);
+        return sysPath.join(root, 'index.js')
+      });
     });
 };
 

--- a/lib/modules.js
+++ b/lib/modules.js
@@ -18,6 +18,7 @@ const generateFileBasedModuleName = moduleNaming.generateFileBasedModuleName;
 
 // Helpers
 
+const slashes = string => string.replace(/\\/g, '/');
 const isDirectory = path => stat(path).then(stats => stats.isDirectory(), () => Promise.resolve(false));
 
 const relativeToRoot = (filePath, relPath) => sysPath.join(
@@ -120,7 +121,7 @@ const _getMainFile = (getPackageJson, filePath) => {
       return helpers.exists(main).then(exists => {
         if (exists || sysPath.relative(root, main) === 'index.js') return main;
 
-        logger.warn(`main file for module ${json.name} does not exist (${sysPath.relative(process.cwd(), main)}), assuming index.js`);
+        logger.warn(`main file for module '${json.name}' does not exist (${sysPath.relative(process.cwd(), main)}), assuming index.js`);
         return sysPath.join(root, 'index.js')
       });
     });
@@ -151,7 +152,20 @@ const globalBrowserMappings = (filePath, brMap) => {
 const generateModule = (getPackageJson, rootMainCache, filePath, source) => {
   const moduleName = generateFileBasedModuleName(filePath);
   let brMap = browserMappings(filePath, getPackageJson, rootMainCache);
-  brMap = globalBrowserMappings(filePath, brMap);
+  const brMap1 = globalBrowserMappings(filePath, brMap);
+  // also pass relative mappings with the false value
+  // e.g. {"./lib/something.js": false} should be handled like {"events": false},
+  // i.e. return an empty object when required
+  const brMap2 = Object.keys(brMap).filter(helpers.isRelative).reduce((newBrMap, key) => {
+    const val = brMap[key];
+    if (!val) {
+      let path = slashes(sysPath.relative(sysPath.dirname(moduleName), sysPath.join(getModuleFullRootName(filePath), key)));
+      if (path[0] !== '.') path = './' + path;
+      newBrMap[path] = false;
+    }
+    return newBrMap;
+  }, {});
+  brMap = Object.assign({}, brMap1, brMap2);
 
   const glob = shims.findGlobals(source);
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "eslint": "^2.4.0"
   },
   "dependencies": {
+    "loggy": "~0.3.0",
     "anymatch": "^1.3.0",
     "async-each": "^1.0.0",
     "browser-resolve": "^1.11.1",


### PR DESCRIPTION
As reported in https://github.com/brunch/brunch/issues/1259

Local file overrides with false values should not register a module, however when required, instead of raising they should simply return an empty object, pretty much like module overrides already work.

Additionally, this PR includes handling of cases when the specified main file cannot be found, which falls back to index.js and prints a warning.
