### PR TITLE
Don't discard babel-runtime declared as devDep from the build

### DIFF
--- a/lib/packages.js
+++ b/lib/packages.js
@@ -9,12 +9,14 @@ const canCallDep = (getPackageJson, path) => {
   const currRoot = moduleNaming.getModuleRootName(path);
   const pkg = getPackageJson(sysPath.resolve(path));
   const deps = Object.assign({}, pkg.dependencies || {}, pkg.peerDependencies || {});
+  const devDeps = Object.assign({}, pkg.devDependencies || {});
   return dep => {
     const root = dep.split('/')[0];
     const browser = typeof pkg.browser === 'object' ? pkg.browser : typeof pkg.browserify === 'object' ? pkg.browserify : {};
     // ignore optional dependencies
     return (isRelative(dep) ||
             root in deps ||
+            (root === 'babel-runtime' && root in devDeps) || // babel-runtime can be declared as a devDep, still needs to be included
             browser[root] && browser[root] in deps ||
             root === currRoot ||
             root in shims.fileShims ||


### PR DESCRIPTION
Closes brunch/brunch#1269

Even if declared as a devDependency, babel-runtime is usually required
in the build (as is the case with "react-on-rails".
