### PR TITLE
Make modMap resemble behavior of commonjs-require-definition aliasing

### DIFF
--- a/lib/project-module-map.js
+++ b/lib/project-module-map.js
@@ -16,11 +16,17 @@ class ProjectModuleMap {
   }
 
   add(mod) {
+    const indexRe = /\/index$/;
+
     // make modMap aware of both fully-qualified and extension-free names of the module
-    const name1 = this.cleanMod(mod);
-    const name2 = this.cleanMod(withoutExt(mod));
-    this.modMap[name1] = mod;
-    this.modMap[name2] = mod;
+    const cleanName = this.cleanMod(mod);
+    const cleanWoExt = this.cleanMod(withoutExt(mod));
+    let indexName;
+    if (indexRe.test(cleanWoExt)) {
+      indexName = cleanWoExt.replace(indexRe, '');
+    }
+
+    [cleanName, cleanWoExt, indexName].filter(x => x).forEach(name => this.modMap[name] = mod);
   }
 
   addMany(obj) {


### PR DESCRIPTION
Closes brunch/brunch#1277

In particular, make sure `./components/Blah` can be resolved to
`app/components/Blah/index.js`
