### PR TITLE
Check for errors before normalizePath

### DIFF
--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -78,11 +78,11 @@ const resolve = (rootPackage, modMap, aliases, globalPseudofile) => (mod, opts, 
   Object.assign(opts, {packageFilter, modules, extensions: ['.js', '.json']});
   mod = aliases && aliases[mod] || mod;
   browserResolve(mod, opts, (err, res) => {
-    res = normalizePath(res);
-
     if (err) {
       return cb(friendlyRequireError(rootPackage, globalPseudofile, mod, opts, err));
     }
+
+    res = normalizePath(res);
 
     const caseError = checkImproperCase(mod, opts, res);
     if (caseError) {


### PR DESCRIPTION
When requiring a non existent module the following error is thrown `TypeError: Cannot read property 'split' of undefined`

This PR fix this issue so a friendly message is displayed.

```
06 Apr 23:47:46 - error: Resolving deps of app/initialize.js failed. Could not load module 'notathing' from '/home/marcio/workspace/javascript/test-brunch/app'. Possible solution: add 'notathing' to package.json and `npm install`. 
```
