### PR TITLE
Make node-resolve work with non-js requires with an extension

### DIFF
--- a/lib/project-module-map.js
+++ b/lib/project-module-map.js
@@ -1,6 +1,11 @@
 'use strict';
 
 const withoutExt = mod => mod.split('.').slice(0, -1).join('.');
+const extRe = /\.(\w+)$/;
+const ext = mod => {
+  const match = extRe.exec(mod)
+  return match && match[1];
+}
 const indexRe = /\/index$/;
 
 // maps project files to module names, also shims
@@ -10,6 +15,7 @@ class ProjectModuleMap {
   constructor(nameCleaner) {
     this.modMap = {};
     this.nameCleaner = nameCleaner;
+    this.exts = {};
   }
 
   cleanMod(mod) {
@@ -21,11 +27,18 @@ class ProjectModuleMap {
     const cleanName = this.cleanMod(mod);
     const cleanWoExt = this.cleanMod(withoutExt(mod));
     const indexName = indexRe.test(cleanWoExt) && cleanWoExt.replace(indexRe, '');
+    if (ext(mod)) {
+      this.exts[ext(mod)] = true;
+    }
     [cleanName, cleanWoExt, indexName].filter(x => x).forEach(name => this.modMap[name] = mod);
   }
 
   addMany(obj) {
     Object.assign(this.modMap, obj);
+  }
+
+  extensions() {
+    return Object.keys(this.exts);
   }
 
   toHash() {

--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -75,7 +75,8 @@ const checkImproperCase = (mod, opts, res) => {
 const resolve = (rootPackage, modMap, aliases, globalPseudofile) => (mod, opts, cb) => {
   const packageFilter = pkg => packages.applyPackageOverrides(pkg, rootPackage);
   const modules = modMap.toHash();
-  Object.assign(opts, {packageFilter, modules, extensions: ['.js', '.json']});
+  const exts = modMap.extensions().map(x => '.' + x);
+  Object.assign(opts, {packageFilter, modules, extensions: ['.js', '.json'].concat(exts)});
   mod = aliases && aliases[mod] || mod;
   browserResolve(mod, opts, (err, res) => {
     if (err) {


### PR DESCRIPTION
GH-30 made handling of relative requires way simpler, by relying on
node-resolve, but it also intorduced a regression when `./Something`
will fail if `Something.js` doesn't exist -- even if `Something.coffee`
does. This commit aims to fix that by telling node-resolve about all the
extensions we know the app code can contain.
