### PR TITLE
Always export deppack methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,17 +3,22 @@ const Deppack = require('./lib/deppack');
 const NoDeppack = require('./lib/no-deppack');
 
 let deppack; // eslint-disable-line prefer-const
+const bindToDeppack = (fnName) => {
+  return function() {
+    if (!deppack) {
+      throw new Error('deppack is not initialized');
+    }
+    return deppack[fnName].apply(deppack, arguments);
+  };
+};
+
+Object.getOwnPropertyNames(Deppack.prototype)
+  .filter(x => x !== 'init' && x !== 'constructor')
+  .forEach(fnName => {
+    exports[fnName] = bindToDeppack(fnName);
+  });
+
 exports.loadInit = (config, json) => {
   deppack = config.npm.enabled ? new Deppack(config, json) : new NoDeppack();
-  exports.exploreDeps = deppack.exploreDeps.bind(deppack);
-  exports.processFiles = deppack.processFiles.bind(deppack);
-  exports.wrapInModule = deppack.wrapInModule.bind(deppack);
-  exports.wrapSourceInModule = deppack.wrapSourceInModule.bind(deppack);
-  exports.needsProcessing = deppack.needsProcessing.bind(deppack);
-  exports.isNpm = deppack.isNpm.bind(deppack);
-  exports.isNpmJSON = deppack.isNpmJSON.bind(deppack);
-  exports.isShim = deppack.isShim.bind(deppack);
-  exports.getAllDependents = deppack.getAllDependents.bind(deppack);
-  exports.graph = () => deppack.depGraph.serialize(deppack.modMap, deppack.fileReflection);
   return deppack.init();
 };

--- a/lib/deppack.js
+++ b/lib/deppack.js
@@ -119,6 +119,10 @@ class Deppack {
 
     return fileDeps.concat(globDeps);
   }
+
+  graph() {
+    return this.depGraph.serialize(this.modMap, this.fileReflection);
+  }
 }
 
 module.exports = Deppack;

--- a/lib/no-deppack.js
+++ b/lib/no-deppack.js
@@ -38,6 +38,10 @@ class NoDeppack {
   getAllDependents() {
     return [];
   }
+
+  graph() {
+    return {};
+  }
 }
 
 module.exports = NoDeppack;


### PR DESCRIPTION
Closes GH-16

Currently, deppack instance methods are only available after it's
initialized, which means Brunch can't have
`const explore = require('deppack').exploreDeps;`

With this change, it will be possible to only import the functions you
need even before deppack itself is initialized.

Since deppack is singleton, i.e., there is not going to be more than one
instance of it, this approach should be okay. (@paulmillr)
