### PR TITLE
Split require.alias definitions between output files

### DIFF
--- a/lib/deppack.js
+++ b/lib/deppack.js
@@ -90,7 +90,8 @@ class Deppack {
   }
 
   processFiles(root, files, processor) {
-    const requiredAliases = modules.requiredAliases(this.rootMainCache, this.getPackageJson, this.usedShims);
+    const filePaths = files.map(f => f.path);
+    const requiredAliases = modules.requiredAliases(this.rootMainCache, this.getPackageJson, this.usedShims, filePaths);
     processFiles(this.npm.aliases || {}, this.npm.globals || {}, this.usedShims, requiredAliases)(root, files, processor);
   }
 

--- a/lib/modules.js
+++ b/lib/modules.js
@@ -58,17 +58,23 @@ const shimAliases = (usedShims) => {
   }, {});
 };
 
-const requiredAliases = (rootMainCache, getPackageJson, usedShims) => {
+const requiredAliases = (rootMainCache, getPackageJson, usedShims, filePaths) => {
   const aliases = Object.keys(rootMainCache).reduce((memo, path) => {
     const file = rootMainCache[path];
     const pkg = getModuleFullRootName(file);
     const name = generateFileBasedModuleName(file);
 
     const brMap = browserMappings(path, getPackageJson, rootMainCache);
-    Object.assign(memo, relativeOverrides(path, brMap));
+    const overrides = relativeOverrides(path, brMap);
     if (name !== pkg + '/index.js') {
-      memo[pkg] = name;
+      overrides[pkg] = name;
     }
+    // only include aliases for the files in this specific bundle
+    Object.keys(overrides).forEach(pkg => {
+      const file = overrides[pkg];
+      if (filePaths.indexOf(`node_modules/${file}`) === -1) return;
+      memo[pkg] = file;
+    });
     return memo;
   }, {});
 


### PR DESCRIPTION
So that aliases for main file as well as browser overrides will only be included in the file that actually contains the source file.

(Note: custom aliases set via `config.npm.aliases` will be included in every bundle, as these are typically module-module mappings (could be `exoskeleton: backbone`), not module-source file mappings.)
