### PR TITLE
Fix global context for non browser environments

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -40,7 +40,7 @@ const processFiles = (configAliases, globals, usedShims, requiredAliases) => (ro
   const proc = usesProcess ? '\nvar process;' : '';
 
   root.add(`\n(function() {
-var global = window;${defs}${proc}${moduleDefinitions.makeRequire}`);
+var global = typeof window === 'undefined' ? global : window;${defs}${proc}${moduleDefinitions.makeRequire}`);
   files.forEach(processor);
   root.add(aliases.join('\n'));
   if (usesProcess) root.add("process = require('process');");

--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -47,7 +47,7 @@ const friendlyRequireError = (rootPackage, globalPseudofile, mod, opts, err) => 
     const mod = data[1];
     const src = data[2];
     const isGlobal = opts.filename === globalPseudofile;
-    
+
     msg = isGlobal ?
       `Could not load global module '${mod}'.` :
       `Could not load module '${mod}' from '${src}'.`;


### PR DESCRIPTION
Problem:

If we ever try to run the bundle generated by this script in an
environment like NodeJS, we will get a "window is not defined" error.

The `window` variable/context may not be present in environments outside
of the browser, in this case, the Global Object is referenced by the
`global` variable, and not `window`.

Solution:

Fall back to the `global` variable, if `window` is not present.
