### PR TITLE
Obtain the global object in more situations.

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -40,7 +40,7 @@ const processFiles = (configAliases, globals, usedShims, requiredAliases) => (ro
   const proc = usesProcess ? '\nvar process;' : '';
 
   root.add(`\n(function() {
-var global = window;${defs}${proc}${moduleDefinitions.makeRequire}`);
+var global = typeof window === 'undefined' ? this : window;${defs}${proc}${moduleDefinitions.makeRequire}`);
   files.forEach(processor);
   root.add(aliases.join('\n'));
   if (usesProcess) root.add("process = require('process');");


### PR DESCRIPTION
When using Brunch to concatenate files (while also using my patch from https://github.com/brunch/commonjs-require-definition/pull/22), and then after loading a concatenated file as a web worker, I get the following error: `Uncaught ReferenceError: window is not defined`. The offending statement is this one: `var global = window;`. This patch allows us to obtain the global object in web workers and other environments.
